### PR TITLE
Check whether the dataset.status is available when waiting a runtime controller for ready

### DIFF
--- a/fluid/api/fluid_k8s_client.py
+++ b/fluid/api/fluid_k8s_client.py
@@ -272,7 +272,7 @@ class FluidK8sClient(object):
         poll = 0
         while poll < poll_timeout:
             dataset = self.get_dataset(name, namespace)
-            if dataset.status.phase == "Bound":
+            if dataset.status is not None and dataset.status.phase == "Bound":
                 logger.debug(f"Dataset \"{namespace}/{name}\" bound successfully")
                 break
             poll += poll_interval


### PR DESCRIPTION
When a runtime is newly created, the `dataset.status` is not available. We'd better check whether it's available.