### PR TITLE
add dockerfile to build image which contains fluid-client-python sdk

### DIFF
--- a/build_image.sh
+++ b/build_image.sh
@@ -1,0 +1,24 @@
+#!/bin/sh
+VERSION=v1.0.0
+GIT_SHA=$(git rev-parse --short HEAD || echo "HEAD")
+GIT_VERSION=${VERSION}-${GIT_SHA}
+IMAGE_REPO=fluidcloudnative
+IMAGE_NAME=${IMAGE_REPO}/fluid-client-python
+
+echo "Building image: ${IMAGE_NAME}:${GIT_VERSION}"
+docker build --no-cache . -f docker/Dockerfile.fluidclientpython -t ${IMAGE_NAME}:${GIT_VERSION}
+
+while getopts "p" opt
+do
+    case $opt in
+        p)
+            echo "Pushing image: ${IMAGE_NAME}:${GIT_VERSION}"
+            docker push ${IMAGE_NAME}:${GIT_VERSION}
+            ;;
+        ?)
+            echo "Usage: build_image.sh [OPTION]"
+            echo "  -p Push the built image"
+            exit 1
+            ;;
+    esac
+done

--- a/docker/Dockerfile.fluidclientpython
+++ b/docker/Dockerfile.fluidclientpython
@@ -1,0 +1,8 @@
+# Build the image which contains the Fluid Client Python SDK
+FROM python:3.8
+
+WORKDIR /fluid-client-python 
+
+COPY . .
+RUN pip install -r requirements.txt
+RUN python setup.py install


### PR DESCRIPTION
To support Fluid Kubeflow Piplines component, we need a base image which contains the Fluid Client Python SDK. This PR add a Dockerfile and a script to build and push this image.